### PR TITLE
Emergency fixes after structure refactoring

### DIFF
--- a/data/chirp_cli_db.csv
+++ b/data/chirp_cli_db.csv
@@ -6,3 +6,4 @@ ropf,"Cheeping cheeps on Chirp :)",1690981487
 peterolufsen,Hello,1725688201
 andrebirk,Hellooo,1725801466
 andrebirk,t.ly/vyr8W,1725801511
+andrebirk,Testing singleton,1726093906

--- a/src/Chirp.CLI.Client/Cheep.cs
+++ b/src/Chirp.CLI.Client/Cheep.cs
@@ -1,6 +1,4 @@
-//namespace Chirp.CLI;
-
-using Chirp.CLI;
+namespace Chirp.CLI.Client;
 
 /**
  * <summary>

--- a/src/Chirp.CLI.Client/Chirp.CLI.Client.csproj
+++ b/src/Chirp.CLI.Client/Chirp.CLI.Client.csproj
@@ -5,16 +5,12 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.0.1" />
-    <PackageReference Include="docopt.net" Version="0.8.1" />
+    <ProjectReference Include="../Chirp.CSVDB/Chirp.CSVDB.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo> 
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo> 
-  </PropertyGroup>
   
 </Project>

--- a/src/Chirp.CLI.Client/HelperFunctions.cs
+++ b/src/Chirp.CLI.Client/HelperFunctions.cs
@@ -1,6 +1,5 @@
 using System.Text.RegularExpressions;
-
-namespace Chirp.CLI;
+namespace Chirp.CLI.Client;
 
 
 /**

--- a/src/Chirp.CLI.Client/Program.cs
+++ b/src/Chirp.CLI.Client/Program.cs
@@ -1,7 +1,9 @@
 ﻿using Chirp.CLI;
-using SimpleDB;
+using Chirp.CLI.Client;
+using Chirp.CSVDB;
 
-string pathToCSV = "./data/chirp_cli_db.csv";
+
+string pathToCSV = "../../data/chirp_cli_db.csv";
 IDatabaseRepository<Cheep> database = new CSVDatabase<Cheep>(pathToCSV);
 long _unixTime = ((DateTimeOffset)DateTime.UtcNow).ToLocalTime().ToUnixTimeSeconds();
 

--- a/src/Chirp.CLI.Client/Program.cs
+++ b/src/Chirp.CLI.Client/Program.cs
@@ -27,5 +27,9 @@ try
             break;
     }
 }
+// error in filepath from database
 catch (FileNotFoundException e) { Console.WriteLine(e.ToString()); }
-catch (Exception) { Console.WriteLine(UserInterface._usage1); }
+// error in switch statement from terminal input
+catch (IndexOutOfRangeException) { Console.WriteLine(UserInterface._usage1); }
+// unknown error from anywhere in program
+catch (Exception e) { Console.WriteLine($"Unknown Exception:\n{e.Message}"); }

--- a/src/Chirp.CLI.Client/Program.cs
+++ b/src/Chirp.CLI.Client/Program.cs
@@ -1,33 +1,31 @@
-﻿using Chirp.CLI;
-using Chirp.CLI.Client;
+﻿using Chirp.CLI.Client;
 using Chirp.CSVDB;
 
+var unixTime = ((DateTimeOffset)DateTime.UtcNow).ToLocalTime().ToUnixTimeSeconds();
+var database = CSVDatabase<Cheep>.GetDatabase();
 
-string pathToCSV = "../../data/chirp_cli_db.csv";
-IDatabaseRepository<Cheep> database = new CSVDatabase<Cheep>(pathToCSV);
-long _unixTime = ((DateTimeOffset)DateTime.UtcNow).ToLocalTime().ToUnixTimeSeconds();
+try
+{
+    switch (args[0])
+    {
+        case "--read":
+            UserInterface.PrintFromDatabaseToConsole(database);
+            break;
 
-
-switch (args[0])
-{ // not sure if this should go into the a function in UserInterface or not
-    case "--read":
-        UserInterface.PrintFromDatabaseToConsole(database);
-        break;
-            
-    case "--chirp":
-        UserInterface.Chirp(Environment.UserName, 
-            string.Join(" ", args.Skip(1)), 
-            _unixTime, 
-            database
-        );
-        break;
-    default:
-        Console.WriteLine(UserInterface._usage1);
-        break;
+        case "--chirp":
+            UserInterface.Chirp(
+                Environment.UserName,
+                string.Join(" ", args.Skip(1)),
+                unixTime,
+                database
+            );
+            break;
+        case "--cheep": // just in case
+            goto case "--chirp";
+        default:
+            Console.WriteLine(UserInterface._usage1);
+            break;
+    }
 }
-
-
-
-
-
-
+catch (FileNotFoundException e) { Console.WriteLine(e.ToString()); }
+catch (Exception) { Console.WriteLine(UserInterface._usage1); }

--- a/src/Chirp.CLI.Client/UserInterface.cs
+++ b/src/Chirp.CLI.Client/UserInterface.cs
@@ -1,6 +1,6 @@
-using SimpleDB;
+using Chirp.CSVDB;
 
-namespace Chirp.CLI;
+namespace Chirp.CLI.Client;
 using System;
 
 /**

--- a/src/Chirp.CSVDB/CSVDatabase.cs
+++ b/src/Chirp.CSVDB/CSVDatabase.cs
@@ -1,8 +1,9 @@
 ﻿using System.Globalization;
+namespace Chirp.CSVDB;
+
 using CsvHelper;
 using CsvHelper.Configuration;
 
-namespace Chirp.CSVDB;
 
 /**
  * <summary>
@@ -13,24 +14,36 @@ namespace Chirp.CSVDB;
  */
 public class CSVDatabase<T> : IDatabaseRepository<T>
 {
+    private static string filePath = "../../data/chirp_cli_db.csv";
     private readonly string _filePath;
-
+    
+    // Singleton for the database
+    private static readonly IDatabaseRepository<T> Database = new CSVDatabase<T>(filePath);
+    
     /**
-     * <summary>Constructor for <c>CSVDatabase</c>
+     * <summary>
+     * Constructor for <c>CSVDatabase</c>. Set to private to ensure no other instance
      * <param name="filePath">The csv-file to communicate with</param>
      * </summary>
-     * 
      */
-    public CSVDatabase(string filePath)
+    private CSVDatabase(string filePath)
     {
-        _filePath = filePath;
+        _filePath = filePath ?? throw new FileNotFoundException(nameof(filePath));
+    }
+    
+    /**
+     * <summary>
+     * A getter method for the singleton of the Database
+     * </summary>
+     */
+    public static IDatabaseRepository<T> GetDatabase()
+    {
+        return Database;
     }
     
 
     /**
-     * <summary>
      * <returns> A list of all records (limit for records is not implemented) </returns>
-     * </summary>
      */
     public List<T> Read(int? limit = null)
     {
@@ -41,9 +54,11 @@ public class CSVDatabase<T> : IDatabaseRepository<T>
     }
 
     /**
+     * <summary>
      * Stores a record or object, by writing into a csv file.
      * The csvConfiguration is set with <c>CultureInfo.InvariantCulture</c>>
      * in order to provide independency from the user's local settings.
+     * </summary>
      */
     public void Store(T record)
     {
@@ -60,3 +75,4 @@ public class CSVDatabase<T> : IDatabaseRepository<T>
         }
     }
 }
+

--- a/src/Chirp.CSVDB/CSVDatabase.cs
+++ b/src/Chirp.CSVDB/CSVDatabase.cs
@@ -2,7 +2,7 @@
 using CsvHelper;
 using CsvHelper.Configuration;
 
-namespace SimpleDB;
+namespace Chirp.CSVDB;
 
 /**
  * <summary>

--- a/src/Chirp.CSVDB/Chirp.CSVDB.csproj
+++ b/src/Chirp.CSVDB/Chirp.CSVDB.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="33.0.1" />
+  </ItemGroup>
+  
 </Project>

--- a/src/Chirp.CSVDB/IDatabaseRepository.cs
+++ b/src/Chirp.CSVDB/IDatabaseRepository.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace SimpleDB;
+namespace Chirp.CSVDB;
 
 /**
  * Interface <c>IDatabaseRepository</c> helps ensure that, whatever implements it,


### PR DESCRIPTION
# 📢 EMERGENCY LATE NIGHT PATCH
Code works again after the refactor.

Changed the '.csproj' files to new names for their respective folders and added 
*<ProjectReference Include="../Chirp.CSVDB/Chirp.CSVDB.csproj" />* to the 'Chirp.CLI.Client.csproj' file
so the *using* could reference the database files.
This caused all the issues!

Also; The old namespaces are changed e.g. SimpleDB -> Chirp.CSVDB, ... -> Chirp.CLI.Client