### PR TITLE
Padding fix for the default message on public timeline

### DIFF
--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -43,7 +43,7 @@
     <div>
         <div class="cheep-item">
 
-            <p class="cheep-body"> Log in to experience new ideas on Chirp. </p>
+            <p class="cheep-body" id = "defaultMessage"> Log in to experience new ideas on Chirp. </p>
         </div>
     </div>
 }

--- a/src/Chirp.Web/wwwroot/css/style.css
+++ b/src/Chirp.Web/wwwroot/css/style.css
@@ -33,6 +33,10 @@ h2, .name-timeline {
   font-size: 15px;
 }
 
+#defaultMessage{
+  padding-bottom: 15px;
+}
+
 .cheep-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Quick fix for the padding after the Likes&Dislikes pull accidently changed the padding of the default message on the public timeline.