### PR TITLE
Extend playwright

### DIFF
--- a/src/Chirp.Infrastructure/Chirp.Repositories/DbInitializer.cs
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/DbInitializer.cs
@@ -159,8 +159,24 @@ public static class DbInitializer
                 LikedCheeps = new List<Cheep>(),
                 Followers = new List<Author>()
             };
+             var a13 = new Author()
+            {
+                Id = "13",
+                UserName = "TestName",
+                Email = "Test@gmail.com",
+                Cheeps = new List<Cheep>(),
+                PasswordHash = "AQAAAAIAAYagAAAAEAqOeK9dWJycTrfn9qds/RY+vYk/0fGD/xqg0j0YVFedT+dcHF7G2R8kjk/DAE+TOA==",
+                NormalizedUserName = "TESTNAME",
+                NormalizedEmail = "TEST@GMAIL.COM",
+                LockoutEnabled = true
+            ,
+                FollowedBy = new List<Author>(),
+                DislikedCheeps = new List<Cheep>(),
+                LikedCheeps = new List<Cheep>(),
+                Followers = new List<Author>()
+            };
 
-            var authors = new List<Author>() { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 };
+            var authors = new List<Author>() { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13 };
 
             var c1 = new Cheep() { Dislikes = new List<Author>(), Likes = new List<Author>(), CheepId = 1, AuthorId = a10.Id, Author = a10, Text = "They were married in Chicago, with old Smith, and was expected aboard every day; meantime, the two went past me.", TimeStamp = DateTime.Parse("2023-08-01 13:14:37") };
             var c2 = new Cheep() { Dislikes = new List<Author>(), Likes = new List<Author>(), CheepId = 2, AuthorId = a10.Id, Author = a10, Text = "And then, as he listened to all that's left o' twenty-one people.", TimeStamp = DateTime.Parse("2023-08-01 13:15:21") };

--- a/test/PlaywrightTests/AzureTests.cs
+++ b/test/PlaywrightTests/AzureTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Playwright;
 using Xunit;
 using Xunit.Sdk;
 namespace PlaywrightTests;
+
 public class AzureTests : IAsyncLifetime
 {
     private IPlaywright? playwright;

--- a/test/PlaywrightTests/LocalTests.cs
+++ b/test/PlaywrightTests/LocalTests.cs
@@ -32,28 +32,6 @@ public class LocalTests : IAsyncLifetime
         context = await browser.NewContextAsync();
     }
 
-
-    [Fact]
-    public async Task LocalRegister()
-    {
-        var page = await context!.NewPageAsync();
-        await page.GotoAsync("http://localhost:5273/");
-        await page.GetByRole(AriaRole.Link, new() { Name = "Logout Log in" }).ClickAsync();
-        await page.GetByRole(AriaRole.Link, new() { Name = "- Register as a new user" }).ClickAsync();
-        await page.GetByText("Register Chirp! Register").PressAsync("ControlOrMeta+z");
-        await page.GetByPlaceholder("Bob").FillAsync("TestName");
-        await page.GetByPlaceholder("name@example.com").DblClickAsync();
-        await page.GetByPlaceholder("name@example.com").FillAsync("Test@gmail.com");
-        await page.GetByLabel("Password", new() { Exact = true }).ClickAsync();
-        await page.GetByLabel("Password", new() { Exact = true }).FillAsync("Chirp123!");
-        await page.GetByLabel("Confirm Password").DblClickAsync();
-        await page.GetByLabel("Confirm Password").FillAsync("Chirp123!");
-        await page.GetByRole(AriaRole.Button, new() { Name = "Register" }).ClickAsync();
-        await page.GetByRole(AriaRole.Link, new() { Name = "Logout Logout[TestName]" }).ClickAsync();
-        await page.GetByRole(AriaRole.Button, new() { Name = "Click here to Logout" }).ClickAsync();
-
-    }
-
     [Fact]
     public async Task LocalLogin()
     {

--- a/test/PlaywrightTests/LocalTests.cs
+++ b/test/PlaywrightTests/LocalTests.cs
@@ -32,6 +32,28 @@ public class LocalTests : IAsyncLifetime
         context = await browser.NewContextAsync();
     }
 
+
+    [Fact]
+    public async Task LocalRegister()
+    {
+        var page = await context!.NewPageAsync();
+        await page.GotoAsync("http://localhost:5273/");
+        await page.GetByRole(AriaRole.Link, new() { Name = "Logout Log in" }).ClickAsync();
+        await page.GetByRole(AriaRole.Link, new() { Name = "- Register as a new user" }).ClickAsync();
+        await page.GetByText("Register Chirp! Register").PressAsync("ControlOrMeta+z");
+        await page.GetByPlaceholder("Bob").FillAsync("TestName");
+        await page.GetByPlaceholder("name@example.com").DblClickAsync();
+        await page.GetByPlaceholder("name@example.com").FillAsync("Test@gmail.com");
+        await page.GetByLabel("Password", new() { Exact = true }).ClickAsync();
+        await page.GetByLabel("Password", new() { Exact = true }).FillAsync("Chirp123!");
+        await page.GetByLabel("Confirm Password").DblClickAsync();
+        await page.GetByLabel("Confirm Password").FillAsync("Chirp123!");
+        await page.GetByRole(AriaRole.Button, new() { Name = "Register" }).ClickAsync();
+        await page.GetByRole(AriaRole.Link, new() { Name = "Logout Logout[TestName]" }).ClickAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = "Click here to Logout" }).ClickAsync();
+
+    }
+
     [Fact]
     public async Task LocalLogin()
     {


### PR DESCRIPTION
This doesn't necesarrily extend playwright, but it get's rid of the manual tasks of registering a user both on the local and azure website.
A user "TestName" has been added to the DbInitializer, so the user exists prior to the tests.