### PR TITLE
updated version for playwright - fixes errors related to browser access

### DIFF
--- a/testPlaywright/PlaywrightTests/AzureTests.cs
+++ b/testPlaywright/PlaywrightTests/AzureTests.cs
@@ -30,7 +30,7 @@ public class AzureTests : IAsyncLifetime
         {
             //To see what the tests "do" you can set this to false
             //and then you can see how it traverses through the website
-            Headless = false,
+            Headless = true,
         });
         context = await browser.NewContextAsync();
     }

--- a/testPlaywright/PlaywrightTests/AzureTests.cs
+++ b/testPlaywright/PlaywrightTests/AzureTests.cs
@@ -23,12 +23,14 @@ public class AzureTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        
         playwright = await Playwright.CreateAsync();
         browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+
         {
             //To see what the tests "do" you can set this to false
             //and then you can see how it traverses through the website
-            Headless = true,
+            Headless = false,
         });
         context = await browser.NewContextAsync();
     }

--- a/testPlaywright/PlaywrightTests/PlaywrightTests.csproj
+++ b/testPlaywright/PlaywrightTests/PlaywrightTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.38.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.50.0-beta-2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
For some reason a problem arises when running the Playwright tests - this has been fixed by ensuring the packagereference within the .csproj file uses the latest version of Playwright.
(This merge will add the newest version of Playwright to the .csproj).