### PR TITLE
External login existing user

### DIFF
--- a/src/Chirp.Web/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -127,6 +127,17 @@ namespace Chirp.Web.Areas.Identity.Pages.Account
                 _logger.LogInformation("{Name} logged in with {LoginProvider} provider.", info.Principal.Identity.Name, info.LoginProvider);
                 return LocalRedirect(returnUrl);
             }
+
+            var userEmail = info.Principal.FindFirstValue(ClaimTypes.Email);
+            var user = await _userManager.FindByEmailAsync(userEmail);
+            if(user != null){
+                var addExternalLogin = await _userManager.AddLoginAsync(user, info);
+                if(addExternalLogin.Succeeded){
+                    await _signInManager.SignInAsync(user, isPersistent: false);
+                    return LocalRedirect(returnUrl);
+                }
+            }
+
             if (result.IsLockedOut)
             {
                 return RedirectToPage("./Lockout");

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Login.cshtml
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Login.cshtml
@@ -32,15 +32,10 @@
                 <div>
                     <button id="login-submit" type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
                 </div>
+                <br>
                 <div>
                     <p>
-                        <a id="forgot-password" asp-page="./ForgotPassword">- Forgot your password?</a>
-                    </p>
-                    <p>
                         <a asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl">- Register as a new user</a>
-                    </p>
-                    <p>
-                        <a id="resend-confirmation" asp-page="./ResendEmailConfirmation">- Resend email confirmation</a>
                     </p>
                 </div>
             </form>


### PR DESCRIPTION
This fixes a bug, where if the user already has an profile on Chirp, then when logging in with an external login that uses the same email, there will be a problem, and the user can't log in.
Now, when the user tries to log in with github, and the user already exists, the github will simply be "added" or "connected" to the user that already exists.